### PR TITLE
Support target temperatures lower than 7.5 in auto mode

### DIFF
--- a/maxcube/cube.py
+++ b/maxcube/cube.py
@@ -293,7 +293,7 @@ class MaxCube(MaxDevice):
                 room = '0' + room
             target_temperature = int(temperature * 2) + (mode << 6)
 
-            byte_cmd = '000440000000' + rf_address + room + hex(target_temperature)[2:]
+            byte_cmd = '000440000000' + rf_address + room + to_hex(target_temperature)
             logger.debug('Request: ' + byte_cmd)
             command = 's:' + base64.b64encode(bytearray.fromhex(byte_cmd)).decode('utf-8') + '\r\n'
             logger.debug('Command: ' + command)


### PR DESCRIPTION
Hallo David,

Entschuldigung, ich spreche kein Deutsch. Ich hoffe, Sie können diese Nachricht auf Englisch verstehen.

I am trying to fix some an issue in Home Assistant which uses your library python-maxcube-api: the temperature is not adjusted when moving from Eco mode to Auto mode. In other words, when I enable the eco mode the temperature is reduced to 14 degrees but when moving back to auto mode it is not restored to whatever is selected in the weekly program.

To fix it, I need to call set_temperature_mode with 0 as the target temperature but there is an small bug in your library when trying to select a temperature lower than 7.5 degrees that this merge request fixes.

Also, I would like to upgrade the version of python-maxcube-api in Home Assistant, but there is no new versions at https://pypi.org/project/maxcube-api/ since 4 years ago. Can you tag a new version and publish it to pypi.org?

Thank you very much!
