### PR TITLE
Update room names when receiving a M message

### DIFF
--- a/maxcube/cube.py
+++ b/maxcube/cube.py
@@ -185,6 +185,8 @@ class MaxCube(MaxDevice):
                 room.id = room_id
                 room.name = name
                 self.rooms.append(room)
+            else:
+                room.name = name
 
         num_devices = data[pos]
         pos += 1

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -211,10 +211,10 @@ class TestMaxCubeExtended(unittest.TestCase):
         self.assertEqual('KEQ0839778', self.cube.devices[2].serial)
         self.assertEqual(1, self.cube.devices[3].room_id)
 
-        self.assertEqual('Badezimmer', self.cube.rooms[0].name)
+        self.assertEqual('Kitchen', self.cube.rooms[0].name)
         self.assertEqual(1, self.cube.rooms[0].id)
 
-        self.assertEqual('Wohnzimmer', self.cube.rooms[1].name)
+        self.assertEqual('Living', self.cube.rooms[1].name)
         self.assertEqual(2, self.cube.rooms[1].id)
 
     def test_parse_l_message(self):


### PR DESCRIPTION
When receiving an M message containing already existing rooms, we need to update the room name instead of ignoring it.