### PR TITLE
Use persistent connections to avoid factory resets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
-  - 2.7
-  - 3.4
-  - 3.5
+  - 3.7
+  - 3.8
+  - 3.9
 
 install:
 - pip install coveralls

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,13 @@
+### Version 0.4.0
+ * Issues fixed:
+   - [MaxCube reset to fatory defaults](https://github.com/hackercowboy/python-maxcube-api/issues/12)
+   - [Unable to change back to scheduled temperature (auto mode)](https://github.com/hackercowboy/python-maxcube-api/issues/24
+
+ * Breaking changes:
+   - Increased minimum supported version of Python to >= 3.7
+   - MaxCubeConnection object removed. MaxCube constructor now receives
+     the host and port parameters directly
+   - The connection is not released after each command is send. This
+     can block other applications to connect to the Max! Cube. You
+     can call cube disconnect() method to release the connection
+     manually.

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Running tests
 
 .. code:: python
 
-   python -m unittest discover tests/
+   python3 -m unittest discover tests/
 
 Acknowledgements
 ================

--- a/maxcube/commander.py
+++ b/maxcube/commander.py
@@ -1,0 +1,126 @@
+import base64
+import logging
+import socket
+
+from time import sleep
+from typing import List
+
+from .connection import Connection
+from .deadline import Deadline, Timeout
+from .message import Message
+
+logger = logging.getLogger(__name__)
+
+QUIT_MSG = Message('q')
+L_MSG = Message('l')
+L_REPLY_CMD = L_MSG.reply_cmd()
+
+UPDATE_TIMEOUT = Timeout('update', 3.0)
+CONNECT_TIMEOUT = Timeout('connect', 3.0)
+FLUSH_INPUT_TIMEOUT = Timeout('flush-input', 0)
+SEND_RADIO_MSG_TIMEOUT = Timeout('send-radio-msg', 30.0)
+CMD_REPLY_TIMEOUT = Timeout('cmd-reply', 2.0)
+
+
+class Commander(object):
+    def __init__(self, host: str, port: int):
+        self.__host: str = host
+        self.__port: int = port
+        self.__connection: Connection = None
+        self.__unsolicited_messages: List[Message] = []
+
+    def disconnect(self):
+        if self.__connection:
+            try:
+                self.__connection.send(QUIT_MSG)
+            except:
+                logger.debug('Unable to properly shutdown MAX Cube connection. Resetting it...')
+            finally:
+                self.__close()
+
+    def get_unsolicited_messages(self) -> List[Message]:
+        result = self.__unsolicited_messages
+        self.__unsolicited_messages = []
+        return result
+
+    def update(self) -> List[Message]:
+        deadline = UPDATE_TIMEOUT.deadline()
+        if self.__is_connected():
+            try:
+                response = self.__call(L_MSG, deadline)
+                if response:
+                    self.__unsolicited_messages.append(response)
+            except:
+                self.__connect(deadline)
+        else:
+            self.__connect(deadline)
+        return self.get_unsolicited_messages()
+
+    def send_radio_msg(self, hex_radio_msg: str) -> bool:
+        deadline = SEND_RADIO_MSG_TIMEOUT.deadline()
+        request = Message('s', base64.b64encode(bytearray.fromhex(hex_radio_msg)).decode('utf-8'))
+        while not deadline.is_expired():
+            if self.__cmd_send_radio_msg(request, deadline):
+                return True
+        return False
+
+    def __cmd_send_radio_msg(self, request: Message, deadline: Deadline) -> bool:
+        try:
+            response = self.__call(request, deadline)
+            duty_cycle, status_code, free_slots = response.arg.split(',', 3)
+            if int(status_code) == 0:
+                return True
+            logger.debug('Radio message %s was not send [DutyCycle:%s, StatusCode:%s, FreeSlots:%s]' %
+                (request, duty_cycle, status_code, free_slots))
+            if int(duty_cycle) == 100 and int(free_slots) == 0:
+                sleep(deadline.remaining(upper_bound=10.0))
+        except Exception as ex:
+            logger.error('Error sending radio message to Max! Cube: ' + str(ex))
+        return False
+
+    def __call(self, msg: Message, deadline: Deadline) -> Message:
+        already_connected = self.__is_connected()
+        if not already_connected:
+            self.__connect(deadline.subtimeout(CONNECT_TIMEOUT))
+        else:
+            # Protection in case some late answer arrives for a previous command
+            self.__wait_for_reply(None, deadline.subtimeout(FLUSH_INPUT_TIMEOUT))
+
+        try:
+            self.__connection.send(msg)
+            subdeadline = deadline.subtimeout(CMD_REPLY_TIMEOUT)
+            result = self.__wait_for_reply(msg.reply_cmd(), subdeadline)
+            if result is None:
+                raise TimeoutError(str(subdeadline))
+            return result
+
+        except:
+            self.__close()
+            if already_connected:
+                return self.__call(msg, deadline)
+            else:
+                raise
+
+    def __is_connected(self) -> bool:
+        return self.__connection is not None
+
+    def __connect(self, deadline: Deadline):
+        self.__unsolicited_messages = []
+        self.__connection = Connection(self.__host, self.__port)
+        reply = self.__wait_for_reply(L_REPLY_CMD, deadline.subtimeout(CMD_REPLY_TIMEOUT))
+        if reply:
+            self.__unsolicited_messages.append(reply)
+
+    def __wait_for_reply(self, reply_cmd: str, deadline: Deadline) -> Message:
+        while True:
+            msg = self.__connection.recv(deadline)
+            if msg is None:
+                return None
+            elif reply_cmd and msg.cmd == reply_cmd:
+                return msg
+            else:
+                self.__unsolicited_messages.append(msg)
+
+    def __close(self):
+        self.__connection.close()
+        self.__connection = None

--- a/maxcube/deadline.py
+++ b/maxcube/deadline.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+from math import inf
+from time import time
+
+
+@dataclass(frozen=True)
+class Timeout:
+    name: str
+    duration: float
+
+    def deadline(self):
+        return Deadline(self.name, time() + self.duration)
+
+class Deadline:
+
+    def __init__(self, name: str, deadline: float, *, parent = None):
+        self.__name = name
+        self.__deadline = deadline
+        self.__parent = parent
+
+    def fullname(self) -> str:
+        if not self.__parent:
+            return self.__name
+        return self.__parent.fullname() + ':' + self.__name
+
+    def remaining(self, *, lower_bound: float = 0, upper_bound: float = inf) -> float:
+        return min(max(lower_bound, self.__deadline - time()), upper_bound)
+
+    def is_expired(self) -> bool:
+        return self.remaining() <= 0
+
+    def subdeadline(self, name, deadline: float) -> 'Deadline':
+        return Deadline(name, min(self.__deadline, deadline), parent = self)
+
+    def subtimeout(self, timeout: Timeout) -> 'Deadline':
+        return self.subdeadline(timeout.name, time() + timeout.duration)
+
+    def __str__(self) -> str:
+        rem = self.remaining(lower_bound=-inf)
+        if rem < 0:
+            return 'Deadline %s expired %.03f seconds ago' % (self.fullname(), -rem)
+        return 'Deadline %s will expire in %.03f seconds' % (self.fullname(), rem)

--- a/maxcube/message.py
+++ b/maxcube/message.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class Message:
+    cmd: str
+    arg: str = ''
+
+    def reply_cmd(self) -> str:
+        return self.cmd.upper()
+
+    def encode(self) -> bytes:
+        return ("%s:%s\r\n" % (self.cmd, self.arg)).encode('utf-8')
+
+    @staticmethod
+    def decode(line: bytes) -> 'Message':
+        comps = line.decode('utf-8').strip().split(':', 1)
+        return Message(comps[0], comps[1] if len(comps) > 1 else '')

--- a/prog.py
+++ b/prog.py
@@ -1,7 +1,6 @@
 import argparse
 import sys
 
-from maxcube.connection import MaxCubeConnection
 from maxcube.cube import MaxCube
 
 
@@ -12,7 +11,7 @@ if __name__ == '__main__':
     parser.add_argument('--port', required=True, type=int)
     parser.add_argument('cmd', choices=['load', 'dump'])
     args = parser.parse_args()
-    cube = MaxCube(MaxCubeConnection(args.host, args.port))
+    cube = MaxCube(args.host, args.port)
     if args.cmd == 'load':
         cube.set_programmes_from_config(sys.stdin)
     elif args.cmd == 'dump':

--- a/sample/sample.py
+++ b/sample/sample.py
@@ -1,5 +1,4 @@
 from maxcube.cube import MaxCube
-from maxcube.connection import MaxCubeConnection
 from maxcube.device import \
     MAX_THERMOSTAT, \
     MAX_THERMOSTAT_PLUS, \
@@ -11,7 +10,7 @@ from maxcube.device import \
     MAX_DEVICE_MODE_BOOST
 import logging
 
-cube = MaxCube(MaxCubeConnection('192.168.0.20', 62910))
+cube = MaxCube('192.168.0.20', 62910)
 
 for room in cube.rooms:
     print("Room: " + room.name)

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,6 @@ setup(
     url='https://github.com/hackercowboy/python-maxcube-api.git',
     license=license,
     packages=['maxcube'],
-    test_suite="tests.maxcube_suite"
+    test_suite="tests",
+    python_requires='>=3.7'
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst') as f:
 
 setup(
     name='maxcube-api',
-    version='0.3.0',
+    version='0.4.0',
     description='eQ-3/ELV MAX! Cube Python API',
     long_description=readme,
     author='David Uebelacker',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,0 @@
-import unittest
-import tests.test_cube
-
-def maxcube_suite():
-    loader = unittest.TestLoader()
-    suite = loader.loadTestsFromModule(test_cube)
-    return suite

--- a/tests/test_commander.py
+++ b/tests/test_commander.py
@@ -1,0 +1,174 @@
+import base64
+
+from unittest import TestCase
+from unittest.mock import MagicMock, call, patch
+from maxcube.commander import Commander
+from maxcube.connection import Connection
+from maxcube.deadline import Deadline, Timeout
+from maxcube.message import Message
+
+L_CMD = Message('l')
+L_CMD_SUCCESS = Message('L')
+S_CMD_HEX = 'FF00'
+S_CMD = Message('s', base64.b64encode(bytearray.fromhex(S_CMD_HEX)).decode('utf-8'))
+S_CMD_SUCCESS = Message('S', '00,0,31')
+S_CMD_ERROR = Message('S', '100,1,31')
+S_CMD_THROTTLE_ERROR = Message('S', '100,1,0')
+
+TEST_TIMEOUT = Timeout('test', 1.0)
+
+@patch('maxcube.commander.Connection', spec=True)
+class TestCommander(TestCase):
+    """ Test Max! Cube command handler """
+
+    def init(self, ClassMock):
+        self.connection = ClassMock.return_value
+        self.commander = Commander('host', 1234)
+
+    def testDisconnectIsNoopIfAlreadyDisconnected(self, ClassMock):
+        self.init(ClassMock)
+        self.commander.disconnect()
+
+        ClassMock.assert_not_called()
+
+        self.connection.send.assert_not_called()
+        self.connection.recv.assert_not_called()
+        self.connection.close.assert_not_called()
+
+    def testUpdateOpensNewConnectionIfDisconnected(self, ClassMock):
+        messages = [Message('H'), Message('L')]
+        self.init(ClassMock)
+        self.connection.recv.side_effect = messages
+
+        self.assertEqual(messages, self.commander.update())
+
+        self.connection.send.assert_not_called()
+        self.assertEqual(2, self.connection.recv.call_count)
+        self.connection.close.assert_not_called()
+
+    def testUpdateSendsCommandAfterAfterTimeout(self, ClassMock):
+        messages = [Message('H'), None]
+        self.init(ClassMock)
+        self.connection.recv.side_effect = messages
+
+        self.assertEqual(messages[:1], self.commander.update())
+
+        self.connection.send.assert_not_called()
+        self.assertEqual(2, self.connection.recv.call_count)
+        self.connection.close.assert_not_called()
+
+        self.connection.recv.reset_mock()
+        self.__mockCommandResponse(L_CMD_SUCCESS)
+
+        self.assertEqual([L_CMD_SUCCESS], self.commander.update())
+
+        self.connection.send.assert_called_once_with(Message('l'))
+        self.assertEqual(2, self.connection.recv.call_count)
+        self.connection.close.assert_not_called()
+
+    def testSendRadioMsgAutoconnects(self, ClassMock = None):
+        self.init(ClassMock)
+        self.connection.recv.side_effect = [
+            L_CMD_SUCCESS, # connection preambule
+            S_CMD_SUCCESS
+        ]
+
+        self.assertTrue(self.commander.send_radio_msg(S_CMD_HEX))
+        self.connection.send.assert_called_once_with(S_CMD)
+        self.assertEqual(2, self.connection.recv.call_count)
+        self.connection.close.assert_not_called()
+
+    def testSendRadioMsgReusesConnection(self, ClassMock):
+        self.testSendRadioMsgAutoconnects()
+
+        self.connection.send.reset_mock()
+        self.connection.recv.reset_mock()
+        self.connection.recv.side_effect = [
+            None,
+            S_CMD_SUCCESS
+        ]
+
+        self.assertTrue(self.commander.send_radio_msg(S_CMD_HEX))
+
+        self.connection.send.assert_called_once_with(S_CMD)
+        self.assertEqual(2, self.connection.recv.call_count)
+        self.connection.close.assert_not_called()
+
+    def testSendRadioMsgClosesConnectionOnErrorAndRetriesIfReusingConnection(self, ClassMock):
+        self.testSendRadioMsgAutoconnects()
+
+        self.connection.recv.reset_mock()
+        self.connection.recv.side_effect = [
+            None, # First read before first try
+        ]
+        self.connection.send.reset_mock()
+        self.connection.send.side_effect = [ OSError ]
+
+        newConnection = MagicMock(Connection)
+        ClassMock.side_effect = [newConnection]
+        newConnection.recv.side_effect = [
+            L_CMD_SUCCESS, # Connection preamble
+            S_CMD_SUCCESS,
+        ]
+
+        self.assertTrue(self.commander.send_radio_msg(S_CMD_HEX))
+
+        self.connection.recv.assert_called_once()
+        self.connection.send.assert_called_once_with(S_CMD)
+        self.connection.close.assert_called_once()
+
+        self.assertEqual(2, newConnection.recv.call_count)
+        newConnection.send.assert_called_once_with(S_CMD)
+        newConnection.close.assert_not_called()
+
+    def __send_radio_msg(self, msg: Message, deadline: Deadline):
+        with patch('maxcube.commander.Timeout.deadline') as deadlineMock:
+            deadlineMock.return_value = deadline
+            return self.commander.send_radio_msg(msg)
+
+    def testSendRadioMsgShouldNotRetryOnErrorWhenConnectionIsNew(self, ClassMock):
+        self.init(ClassMock)
+        self.connection.recv.side_effect = [ L_CMD_SUCCESS ]
+        self.connection.send.side_effect = [ OSError ]
+
+        deadline = MagicMock(Deadline)
+        deadline.is_expired.side_effect = [False, True]
+        deadline.subtimeout.return_value = TEST_TIMEOUT.deadline()
+
+        self.assertFalse(self.__send_radio_msg(S_CMD_HEX, deadline))
+
+        self.connection.send.assert_called_once_with(S_CMD)
+        self.connection.recv.assert_called_once()
+        self.connection.close.assert_called_once()
+
+    def testSendRadioMsgFailsOnLogicalError(self, ClassMock):
+        self.init(ClassMock)
+        self.connection.recv.side_effect = [ L_CMD_SUCCESS, S_CMD_ERROR ]
+
+        deadline: Deadline = MagicMock(Deadline)
+        deadline.is_expired.side_effect = [False, True]
+        deadline.subtimeout.return_value = TEST_TIMEOUT.deadline()
+        self.assertFalse(self.__send_radio_msg(S_CMD_HEX, deadline))
+
+        self.connection.send.assert_called_once_with(S_CMD)
+        self.assertEqual(2, self.connection.recv.call_count)
+        self.connection.close.assert_not_called()
+        deadline.remaining.assert_not_called()
+
+    def testSendRadioMsgRetriesOnThrottlingError(self, ClassMock):
+        self.init(ClassMock)
+        self.connection.recv.side_effect = [ L_CMD_SUCCESS, S_CMD_THROTTLE_ERROR ]
+
+        deadline: Deadline = MagicMock(Deadline)
+        deadline.is_expired.side_effect = [False, True]
+        deadline.remaining.return_value = 0.1
+        deadline.subtimeout.return_value = TEST_TIMEOUT.deadline()
+        self.assertFalse(self.__send_radio_msg(S_CMD_HEX, deadline))
+
+        self.connection.send.assert_called_once_with(S_CMD)
+        self.assertEqual(2, self.connection.recv.call_count)
+        self.connection.close.assert_not_called()
+        deadline.remaining.assert_called_once()
+
+    def __mockCommandResponse(self, response):
+        self.connection.recv.side_effect = [None, response]

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,70 @@
+import socket
+
+from unittest import TestCase
+from unittest.mock import MagicMock, call, patch
+from maxcube.commander import Commander
+from maxcube.connection import Connection
+from maxcube.deadline import Deadline, Timeout
+from maxcube.message import Message
+
+TEST_TIMEOUT = Timeout('test', 1000.0)
+
+@patch('socket.socket', spec=True)
+class TestConnection(TestCase):
+    """ Test Max! Cube connections """
+
+    def connect(self, socketMock):
+        self.socket = socketMock.return_value
+        self.connection = Connection('host', 1234)
+        self.socket.settimeout.assert_called_once_with(2.0)
+        self.socket.connect.assert_called_once_with(('host', 1234))
+
+    def testReadAMessage(self, socketMock):
+        self.connect(socketMock)
+        self.socket.recv.return_value = b'A:B\r\n'
+
+        self.assertEquals(Message('A', 'B'),
+            self.connection.recv(TEST_TIMEOUT.deadline()))
+        self.socket.close.assert_not_called()
+
+    def testReadPartialLine(self, socketMock):
+        self.connect(socketMock)
+        self.socket.recv.side_effect = [b'A:', b'B\r\n']
+
+        self.assertEquals(Message('A', 'B'),
+            self.connection.recv(TEST_TIMEOUT.deadline()))
+
+    def testReadMultipleLines(self, socketMock):
+        self.connect(socketMock)
+        self.socket.recv.return_value = b'A:B\r\nC\r\n'
+
+        self.assertEquals(Message('A', 'B'),
+            self.connection.recv(TEST_TIMEOUT.deadline()))
+        self.socket.recv.reset_mock()
+        self.assertEquals(Message('C', ''),
+            self.connection.recv(TEST_TIMEOUT.deadline()))
+
+    def testReadAtConnectionClosing(self, socketMock):
+        self.connect(socketMock)
+        self.socket.recv.return_value = b''
+
+        self.assertIsNone(self.connection.recv(TEST_TIMEOUT.deadline()))
+        self.socket.close.assert_called_once()
+
+    def testReadTimeout(self, socketMock):
+        self.connect(socketMock)
+        self.socket.recv.side_effect = [socket.timeout]
+
+        self.assertIsNone(self.connection.recv(TEST_TIMEOUT.deadline()))
+        self.socket.close.assert_not_called()
+
+    def testSendMessage(self, socketMock):
+        self.connect(socketMock)
+        self.connection.send(Message('A', 'B'))
+        self.socket.send.assert_called_with(b'A:B\r\n')
+
+    def testCloseErrorsAreIgnored(self, socketMock):
+        self.connect(socketMock)
+        self.socket.close.side_effect = [OSError]
+        self.connection.close()
+        self.socket.close.assert_called_once()

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -1,5 +1,8 @@
-import unittest
-from maxcube.connection import MaxCubeConnection
+from typing import List
+from unittest import TestCase
+from unittest.mock import MagicMock, call, patch
+from maxcube.commander import Commander
+from maxcube.message import Message
 from maxcube.cube import MaxCube
 from maxcube.device import \
     MaxDevice, \
@@ -13,164 +16,229 @@ from maxcube.device import \
     MAX_DEVICE_MODE_BOOST
 from maxcube.room import MaxRoom
 
-INIT_RESPONSE_1 = \
-    'H:KEQ0566338,0b6475,0113,00000000,74b7b6f7,00,32,0f0c19,1527,03,0000\n\r' \
-    'M:00,01,VgIEAQdLaXRjaGVuBrxTAgZMaXZpbmcGvFoDCFNsZWVwaW5nCKuCBARXb3JrBrxcBAEGvFNLRVEwMzM2MTA4B0tpdGNoZW4BAQa8Wk' \
-    'tFUTAzMzYxMDAGTGl2aW5nAgEIq4JLRVEwMzM1NjYyCFNsZWVwaW5nAwEGvFxLRVEwMzM2MTA0BFdvcmsEAQ==\r\n' \
-    'C:0b6475,7QtkdQATAf9LRVEwNTY2MzM4AQsABEAAAAAAAAAAAP///////////////////////////wsABEAAAAAAAAAAQf////////////////' \
-    '///////////2h0dHA6Ly93d3cubWF4LXBvcnRhbC5lbHYuZGU6ODAvY3ViZQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' \
-    'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAENFVAAACgADAAAOEENFU1QAAwACAAAcIA==\r\n' \
-    'C:06bc53,0ga8UwEBGP9LRVEwMzM2MTA4KCEyCQcYAzAM/wBESFUIRSBFIEUgRSBFIEUgRSBFIEUgRSBFIERIVQhFIEUgRSBFIEUgRSBFIEUgRS' \
-    'BFIEUgREhUbETMVRRFIEUgRSBFIEUgRSBFIEUgRSBESFRsRMxVFEUgRSBFIEUgRSBFIEUgRSBFIERIVGxEzFUURSBFIEUgRSBFIEUgRSBFIEUgR' \
-    'EhUbETMVRRFIEUgRSBFIEUgRSBFIEUgRSBESFRsRMxVFEUgRSBFIEUgRSBFIEUgRSBFIA==\r\n' \
-    'C:06bc5a,0ga8WgECGP9LRVEwMzM2MTAwKCEyCQcYAzAM/wBESFUIRSBFIEUgRSBFIEUgRSBFIEUgRSBFIERIVQhFIEUgRSBFIEUgRSBFIEUgRS' \
-    'BFIEUgREhUbETMVRRFIEUgRSBFIEUgRSBFIEUgRSBESFRsRMxVFEUgRSBFIEUgRSBFIEUgRSBFIERIVGxEzFUURSBFIEUgRSBFIEUgRSBFIEUgR' \
-    'EhUbETMVRRFIEUgRSBFIEUgRSBFIEUgRSBESFRsRMxVFEUgRSBFIEUgRSBFIEUgRSBFIA==\r\n' \
-    'C:06bc5c,0ga8XAEEGP9LRVEwMzM2MTA0KCEyCQcYAzAM/wBESFUIRSBFIEUgRSBFIEUgRSBFIEUgRSBFIERIVQhFIEUgRSBFIEUgRSBFIEUgR' \
-    'SBFIEUgREhUbETMVRRFIEUgRSBFIEUgRSBFIEUgRSBESFRsRMxVFEUgRSBFIEUgRSBFIEUgRSBFIERIVGxEzFUURSBFIEUgRSBFIEUgRSBFIEU' \
-    'gREhUbETMVRRFIEUgRSBFIEUgRSBFIEUgRSBESFRsRMxVFEUgRSBFIEUgRSBFIEUgRSBFIA==\r\n' \
-    'C:08ab82,0girggEDGP9LRVEwMzM1NjYyKCEyCQcYAzAM/wBEYFRsRMxFFEUgRSBFIEUgRSBFIEUgRSBFIERgVGxEzEUURSBFIEUgRSBFIEUgR' \
-    'SBFIEUgRGBUbETMRRRFIEUgRSBFIEUgRSBFIEUgRSBEYFRsRMxFFEUgRSBFIEUgRSBFIEUgRSBFIERgVGxEzEUURSBFIEUgRSBFIEUgRSBFIEU' \
-    'gRGBUbETMRRRFIEUgRSBFIEUgRSBFIEUgRSBEYFRsRMxFFEUgRSBFIEUgRSBFIEUgRSBFIA==\r\n' \
-    'L:Cwa8U/EaGBsqAOwACwa8WgkSGCMqAOcACwa8XAkSGAsqAOcACwirggMaGAAiAAAA'
+def to_messages(lines):
+    return [ Message.decode(line) for line in lines]
 
-INIT_RESPONSE_2 = \
-    'H:JEQ0341267,015d2a,0113,00000000,0336f10a,4b,29,110203,172a,03,0000\n\r' \
-    'M:00,01,VgICAQpCYWRlemltbWVyDi66AgpXb2huemltbWVyAAAAAwEOLrpLRVExMDg2NDM3ClRoZXJtb3N0YXQBAwoIgUtFUTA2NTU3NDMOV2' \
-    'FuZHRoZXJtb3N0YXQCBAyisktFUTA4Mzk3NzgORmVuc3RlcmtvbnRha3QBAQ==\n\r' \
-    'C:015d2a,7QFdKgATAf9KRVEwMzQxMjY3AQsABEAAAAAAAAAAAP///////////////////////////wsABEAAAAAAAAAAQf///////////////' \
-    '////////////2h0dHA6Ly9tYXguZXEtMy5kZTo4MC9jdWJlADAvbG9va3VwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' \
-    'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAENFVAAACgADAAAOEENFU1QAAwACAAAcIA==' \
-    '\n\r' \
-    'C:0a0881,zgoIgQMCEP9LRVEwNjU1NzQzKyE9CURIVQhFIEUgRSBFIEUgRSBFIEUgRSBFIEUgREhVCEUgRSBFIEUgRSBFIEUgRSBFIEUgRSBES' \
-    'FRsRMxVFEUgRSBFIEUgRSBFIEUgRSBFIERIVGxEzFUURSBFIEUgRSBFIEUgRSBFIEUgREhUbETMVRRFIEUgRSBFIEUgRSBFIEUgRSBESFRsRMx' \
-    'VFEUgRSBFIEUgRSBFIEUgRSBFIERIVGxEzFUURSBFIEUgRSBFIEUgRSBFIEUgBxgw\n\r' \
-    'C:0ca2b2,EQyisgQBFA9LRVEwODM5Nzc4\n\r' \
-    'C:0e2eba,0g4uugEBEKBLRVExMDg2NDM3KyE9CQcYAzAM/wAgYFR4ISAhICEgISAhIEUgRSBFIEUgRSBFICBgVHghICEgISAhICEgRSBFIEUgR' \
-    'SBFIEUgIEJUTiEfISAhICEgISBFIEUgRSBFIEUgRSAgQlROIR8hICEgISAhIEUgRSBFIEUgRSBFICBCVE4hHyEgISAhICEgRSBFIEUgRSBFIEU' \
-    'gIEJUTiEfISAhICEgISBFIEUgRSBFIEUgRSAgQlROIR8hICEgISAhIEUgRSBFIEUgRSBFIA==\n\r' \
-    'L:DAoIgewSGAQQAAAA5QYMorL3EhALDi66ChIYABAAAAA=\n\r'
+INIT_RESPONSE_1 = to_messages([
+    b'H:KEQ0566338,0b6475,0113,00000000,74b7b6f7,00,32,0f0c19,1527,03,0000',
+    b'M:00,01,VgIEAQdLaXRjaGVuBrxTAgZMaXZpbmcGvFoDCFNsZWVwaW5nCKuCBARXb3JrBrxcBAEGvFNLRVEwMzM2MTA4B0tpdGNoZW4BAQa8Wk' \
+    b'tFUTAzMzYxMDAGTGl2aW5nAgEIq4JLRVEwMzM1NjYyCFNsZWVwaW5nAwEGvFxLRVEwMzM2MTA0BFdvcmsEAQ==',
+    b'C:0b6475,7QtkdQATAf9LRVEwNTY2MzM4AQsABEAAAAAAAAAAAP///////////////////////////wsABEAAAAAAAAAAQf////////////////' \
+    b'///////////2h0dHA6Ly93d3cubWF4LXBvcnRhbC5lbHYuZGU6ODAvY3ViZQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' \
+    b'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAENFVAAACgADAAAOEENFU1QAAwACAAAcIA==',
+    b'C:06bc53,0ga8UwEBGP9LRVEwMzM2MTA4KCEyCQcYAzAM/wBESFUIRSBFIEUgRSBFIEUgRSBFIEUgRSBFIERIVQhFIEUgRSBFIEUgRSBFIEUgRS' \
+    b'BFIEUgREhUbETMVRRFIEUgRSBFIEUgRSBFIEUgRSBESFRsRMxVFEUgRSBFIEUgRSBFIEUgRSBFIERIVGxEzFUURSBFIEUgRSBFIEUgRSBFIEUgR' \
+    b'EhUbETMVRRFIEUgRSBFIEUgRSBFIEUgRSBESFRsRMxVFEUgRSBFIEUgRSBFIEUgRSBFIA==',
+    b'C:06bc5a,0ga8WgECGP9LRVEwMzM2MTAwKCEyCQcYAzAM/wBESFUIRSBFIEUgRSBFIEUgRSBFIEUgRSBFIERIVQhFIEUgRSBFIEUgRSBFIEUgRS' \
+    b'BFIEUgREhUbETMVRRFIEUgRSBFIEUgRSBFIEUgRSBESFRsRMxVFEUgRSBFIEUgRSBFIEUgRSBFIERIVGxEzFUURSBFIEUgRSBFIEUgRSBFIEUgR' \
+    b'EhUbETMVRRFIEUgRSBFIEUgRSBFIEUgRSBESFRsRMxVFEUgRSBFIEUgRSBFIEUgRSBFIA==',
+    b'C:06bc5c,0ga8XAEEGP9LRVEwMzM2MTA0KCEyCQcYAzAM/wBESFUIRSBFIEUgRSBFIEUgRSBFIEUgRSBFIERIVQhFIEUgRSBFIEUgRSBFIEUgR' \
+    b'SBFIEUgREhUbETMVRRFIEUgRSBFIEUgRSBFIEUgRSBESFRsRMxVFEUgRSBFIEUgRSBFIEUgRSBFIERIVGxEzFUURSBFIEUgRSBFIEUgRSBFIEU' \
+    b'gREhUbETMVRRFIEUgRSBFIEUgRSBFIEUgRSBESFRsRMxVFEUgRSBFIEUgRSBFIEUgRSBFIA==',
+    b'C:08ab82,0girggEDGP9LRVEwMzM1NjYyKCEyCQcYAzAM/wBEYFRsRMxFFEUgRSBFIEUgRSBFIEUgRSBFIERgVGxEzEUURSBFIEUgRSBFIEUgR' \
+    b'SBFIEUgRGBUbETMRRRFIEUgRSBFIEUgRSBFIEUgRSBEYFRsRMxFFEUgRSBFIEUgRSBFIEUgRSBFIERgVGxEzEUURSBFIEUgRSBFIEUgRSBFIEU' \
+    b'gRGBUbETMRRRFIEUgRSBFIEUgRSBFIEUgRSBEYFRsRMxFFEUgRSBFIEUgRSBFIEUgRSBFIA==',
+    b'L:Cwa8U/EaGBsqAOwACwa8WgkSGCMqAOcACwa8XAkSGAsqAOcACwirggMaGAAiAAAA'
+])
 
-INIT_PROGRAMME_1 = {'monday': [{'until': '05:30', 'temp': 8}, {'until': '06:30', 'temp': 21}, {'until': '23:55', 'temp': 8}, {'until': '24:00', 'temp': 8}], 'tuesday': [{'until': '05:30', 'temp': 8}, {'until': '06:30', 'temp': 21}, {'until': '23:55', 'temp': 8}, {'until': '24:00', 'temp': 8}], 'friday': [{'until': '05:30', 'temp': 8}, {'until': '06:30', 'temp': 21}, {'until': '23:55', 'temp': 8}, {'until': '24:00', 'temp': 8}], 'wednesday': [{'until': '05:30', 'temp': 8}, {'until': '06:30', 'temp': 21}, {'until': '23:55', 'temp': 8}, {'until': '24:00', 'temp': 8}], 'thursday': [{'until': '05:30', 'temp': 8}, {'until': '06:30', 'temp': 21}, {'until': '23:55', 'temp': 8}, {'until': '24:00', 'temp': 8}], 'sunday': [{'until': '08:00', 'temp': 8}, {'until': '10:00', 'temp': 21}, {'until': '24:00', 'temp': 8}], 'saturday': [{'until': '08:00', 'temp': 8}, {'until': '10:00', 'temp': 21}, {'until': '24:00', 'temp': 8}]}
+INIT_RESPONSE_2 = to_messages([
+    b'H:JEQ0341267,015d2a,0113,00000000,0336f10a,4b,29,110203,172a,03,0000',
+    b'M:00,01,VgICAQpCYWRlemltbWVyDi66AgpXb2huemltbWVyAAAAAwEOLrpLRVExMDg2NDM3ClRoZXJtb3N0YXQBAwoIgUtFUTA2NTU3NDMOV2' \
+    b'FuZHRoZXJtb3N0YXQCBAyisktFUTA4Mzk3NzgORmVuc3RlcmtvbnRha3QBAQ==',
+    b'C:015d2a,7QFdKgATAf9KRVEwMzQxMjY3AQsABEAAAAAAAAAAAP///////////////////////////wsABEAAAAAAAAAAQf///////////////' \
+    b'////////////2h0dHA6Ly9tYXguZXEtMy5kZTo4MC9jdWJlADAvbG9va3VwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' \
+    b'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAENFVAAACgADAAAOEENFU1QAAwACAAAcIA==',
+    b'C:0a0881,zgoIgQMCEP9LRVEwNjU1NzQzKyE9CURIVQhFIEUgRSBFIEUgRSBFIEUgRSBFIEUgREhVCEUgRSBFIEUgRSBFIEUgRSBFIEUgRSBES' \
+    b'FRsRMxVFEUgRSBFIEUgRSBFIEUgRSBFIERIVGxEzFUURSBFIEUgRSBFIEUgRSBFIEUgREhUbETMVRRFIEUgRSBFIEUgRSBFIEUgRSBESFRsRMx' \
+    b'VFEUgRSBFIEUgRSBFIEUgRSBFIERIVGxEzFUURSBFIEUgRSBFIEUgRSBFIEUgBxgw',
+    b'C:0ca2b2,EQyisgQBFA9LRVEwODM5Nzc4',
+    b'C:0e2eba,0g4uugEBEKBLRVExMDg2NDM3KyE9CQcYAzAM/wAgYFR4ISAhICEgISAhIEUgRSBFIEUgRSBFICBgVHghICEgISAhICEgRSBFIEUgR' \
+    b'SBFIEUgIEJUTiEfISAhICEgISBFIEUgRSBFIEUgRSAgQlROIR8hICEgISAhIEUgRSBFIEUgRSBFICBCVE4hHyEgISAhICEgRSBFIEUgRSBFIEU' \
+    b'gIEJUTiEfISAhICEgISBFIEUgRSBFIEUgRSAgQlROIR8hICEgISAhIEUgRSBFIEUgRSBFIA==',
+    b'L:DAoIgewSGAQQAAAA5QYMorL3EhALDi66ChIYABAAAAA='
+])
+
+LAST_STATE_MSG = Message.decode(b'L:Cwa8U/ESGAAiAAAACwa8WgkSGAAiAAAACwa8XAkSGAUiAAAACwirggMSGAUiAAAA')
+
+SEND_CMD_OK_RESPONSE = 'S:04,0,31'
+
+WORKDAY_PROGRAMME_1 = [
+    {'until': '05:30', 'temp': 8},
+    {'until': '06:30', 'temp': 21},
+    {'until': '23:55', 'temp': 8},
+    {'until': '24:00', 'temp': 8}
+]
+
+WEEKEND_PROGRAME_1 = [
+    {'until': '08:00', 'temp': 8},
+    {'until': '10:00', 'temp': 21},
+    {'until': '24:00', 'temp': 8}
+]
+
+INIT_PROGRAMME_1 = {
+    'monday': WORKDAY_PROGRAMME_1,
+    'tuesday': WORKDAY_PROGRAMME_1,
+    'wednesday': WORKDAY_PROGRAMME_1,
+    'thursday': WORKDAY_PROGRAMME_1,
+    'friday': WORKDAY_PROGRAMME_1,
+    'saturday': WEEKEND_PROGRAME_1,
+    'sunday': WEEKEND_PROGRAME_1
+}
 
 
-class MaxCubeConnectionMock(MaxCubeConnection):
-    def __init__(self, init_response):
-        super(MaxCubeConnectionMock, self).__init__(None, None)
-        self.command = None
-        self.init_response = init_response
-
-    def connect(self):
-        self.response = self.init_response
-        return
-
-    def send(self, command):
-        self.command = command
-
-    def disconnect(self):
-        return
-
-
-class TestMaxCube(unittest.TestCase):
+@patch('maxcube.cube.Commander', spec=True)
+class TestMaxCube(TestCase):
     """ Test the Max! Cube. """
 
-    def setUp(self):
-        self.cube = MaxCube(MaxCubeConnectionMock(INIT_RESPONSE_1))
+    def init(self, ClassMock, responses):
+        self.commander = ClassMock.return_value
+        self.commander.update.return_value = responses
 
-    def test_init(self):
+        self.cube = MaxCube('host', 1234)
+
+        self.commander.update.assert_called_once()
+        self.commander.update.reset_mock()
+        self.commander.send_radio_msg.return_value = True
+
+    def test_init(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_1)
         self.assertEqual('0b6475', self.cube.rf_address)
         self.assertEqual('Cube', self.cube.name)
         self.assertEqual('01.13', self.cube.firmware_version)
         self.assertEqual(4, len(self.cube.devices))
 
-    def test_parse_response(self):
-        self.cube.parse_response(INIT_RESPONSE_1)
-        self.assertEqual('0b6475', self.cube.rf_address)
-        self.assertEqual('Cube', self.cube.name)
-        self.assertEqual('01.13', self.cube.firmware_version)
-        self.assertEqual(4, len(self.cube.devices))
-
-    def test_parse_c_message(self):
-        self.cube.parse_c_message('C:0b6475,7QtkdQATAf9LRVEwNTY2MzM4AAsABEAAAAAAAAAAAP///////////////////////////'
-                                  'wsABEAAAAAAAAAAQf///////////////////////////2h0dHA6Ly93d3cubWF4LXBvcnRhbC5lbHY'
-                                  'uZGU6ODAvY3ViZQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
-                                  'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAENFVAAACgADAAAOEEN'
-                                  'FU1QAAwACAAAcIA==')
         device = self.cube.devices[0]
         self.assertEqual(4.5, device.min_temperature)
         self.assertEqual(25.0, device.max_temperature)
+        self.assertEqual('06BC53', device.rf_address)
+        self.assertEqual('Kitchen', device.name)
 
-    def test_parse_h_message(self):
-        self.cube.parse_h_message('H:KEQ0566338,0b6444,0113,00000000,335b04d2,33,32,0f0c1d,101c,03,0000')
-        self.assertEqual('0b6444', self.cube.rf_address)
-        self.assertEqual('01.13', self.cube.firmware_version)
-
-    def test_parse_m_message(self):
-        self.cube.parse_m_message('M:00,01,VgIEAQdLaXRjaGVuBrxTAgZMaXZpbmcGvFoDCFNsZWVwaW5nCKuCBARXb3JrBrxcBAEGvF'
-                                  'NLRVEwMzM2MTA4B0tpdGNoZW4BAQa8WktFUTAzMzYxMDAGTGl2aW5nAgEIq4JLRVEwMzM1NjYyCFNs'
-                                  'ZWVwaW5nAwEGvFxLRVEwMzM2MTA0BFdvcmsEAQ==')
-        self.assertEqual('06BC53', self.cube.devices[0].rf_address)
-        self.assertEqual('Kitchen', self.cube.devices[0].name)
         self.assertEqual('06BC5A', self.cube.devices[1].rf_address)
         self.assertEqual('Living', self.cube.devices[1].name)
+
         self.assertEqual('08AB82', self.cube.devices[2].rf_address)
         self.assertEqual('Sleeping', self.cube.devices[2].name)
+
         self.assertEqual('06BC5C', self.cube.devices[3].rf_address)
         self.assertEqual('Work', self.cube.devices[3].name)
 
-    def test_parse_l_message(self):
-        self.cube.parse_l_message('L:Cwa8U/ESGAAiAAAACwa8WgkSGAAiAAAACwa8XAkSGAUiAAAACwirggMSGAUiAAAA')
+    def __update(self, responses: List[Message]):
+        self.commander.update.return_value=responses
+        self.cube.update()
+        self.commander.update.assert_called_once()
+
+    def test_parse_auto_l_message(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_1)
+        self.__update([LAST_STATE_MSG])
+
         device = self.cube.devices[0]
         self.assertEqual(MAX_DEVICE_MODE_AUTOMATIC, device.mode)
         self.assertEqual(23.6, device.actual_temperature)
         self.assertEqual(17.0, device.target_temperature)
-        self.cube.parse_l_message('L:Cwa8U/ESGQkhALMACwa8WgkSGQAhAMAACwa8XAkSGQUhALIACwirggMSGQUhAAAA')
+
+    def test_parse_manual_l_message(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_1)
+        self.__update([Message.decode(b'L:Cwa8U/ESGQkhALMACwa8WgkSGQAhAMAACwa8XAkSGQUhALIACwirggMSGQUhAAAA')])
+
         device = self.cube.devices[0]
         self.assertEqual(MAX_DEVICE_MODE_MANUAL, device.mode)
         self.assertEqual(17.9, device.actual_temperature)
         self.assertEqual(16.5, device.target_temperature)
 
-    def test_resolve_device_mode(self):
-        self.assertEqual(MAX_DEVICE_MODE_AUTOMATIC, self.cube.resolve_device_mode(24))
-        self.assertEqual(MAX_DEVICE_MODE_MANUAL, self.cube.resolve_device_mode(25))
+    def test_disconnect(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_1)
+        self.cube.disconnect()
+        self.commander.disconnect.assert_called_once()
 
-    def test_is_thermostat(self):
+    def test_is_thermostat(self, _):
         device = MaxDevice()
         device.type = MAX_CUBE
-        self.assertEqual(False, device.is_thermostat())
+        self.assertFalse(device.is_thermostat())
         device.type = MAX_THERMOSTAT
-        self.assertEqual(True, device.is_thermostat())
+        self.assertTrue(device.is_thermostat())
         device.type = MAX_THERMOSTAT_PLUS
-        self.assertEqual(True, device.is_thermostat())
+        self.assertTrue(device.is_thermostat())
+        device.type = MAX_WALL_THERMOSTAT
+        self.assertFalse(device.is_thermostat())
+        device.type = MAX_WINDOW_SHUTTER
+        self.assertFalse(device.is_thermostat())
 
-    def test_set_target_temperature(self):
-        self.cube.set_target_temperature(self.cube.devices[0], 24.5)
-        self.assertEqual('s:AARAAAAABrxTATE=\r\n', self.cube.connection.command)
+    def test_is_wall_thermostat(self, _):
+        device = MaxDevice()
+        device.type = MAX_CUBE
+        self.assertFalse(device.is_wallthermostat())
+        device.type = MAX_THERMOSTAT
+        self.assertFalse(device.is_wallthermostat())
+        device.type = MAX_THERMOSTAT_PLUS
+        self.assertFalse(device.is_wallthermostat())
+        device.type = MAX_WALL_THERMOSTAT
+        self.assertTrue(device.is_wallthermostat())
+        device.type = MAX_WINDOW_SHUTTER
+        self.assertFalse(device.is_wallthermostat())
+
+    def test_is_window_shutter(self, _):
+        device = MaxDevice()
+        device.type = MAX_CUBE
+        self.assertFalse(device.is_windowshutter())
+        device.type = MAX_THERMOSTAT
+        self.assertFalse(device.is_windowshutter())
+        device.type = MAX_THERMOSTAT_PLUS
+        self.assertFalse(device.is_windowshutter())
+        device.type = MAX_WALL_THERMOSTAT
+        self.assertFalse(device.is_windowshutter())
+        device.type = MAX_WINDOW_SHUTTER
+        self.assertTrue(device.is_windowshutter())
+
+    def test_set_target_temperature(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_1)
+
+        self.assertTrue(self.cube.set_target_temperature(self.cube.devices[0], 24.5))
+
         self.assertEqual(24.5, self.cube.devices[0].target_temperature)
+        self.commander.send_radio_msg.assert_called_once()
+        self.commander.send_radio_msg.assert_called_with('00044000000006BC530131')
+
+    def test_do_not_update_if_set_target_temperature_fails(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_1)
+        self.commander.send_radio_msg.return_value = False
+
+        self.assertFalse(self.cube.set_target_temperature(self.cube.devices[0], 24.5))
+
+        self.assertEqual(21, self.cube.devices[0].target_temperature)
+        self.commander.send_radio_msg.assert_called_once()
+        self.commander.send_radio_msg.assert_called_with('00044000000006BC530131')
+
+    def test_set_target_temperature_should_round_temperature(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_1)
+
         self.cube.set_target_temperature(self.cube.devices[0], 24.6)
+
         self.assertEqual(24.5, self.cube.devices[0].target_temperature)
+        self.commander.send_radio_msg.assert_called_once()
+        self.commander.send_radio_msg.assert_called_with('00044000000006BC530131')
 
+    def test_set_target_temperature_is_ignored_by_windowshutter(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_2)
+        self.cube.set_target_temperature(self.cube.devices[2], 24.5)
+        self.commander.send_radio_msg.assert_not_called()
 
-class TestMaxCubeExtended(unittest.TestCase):
-    """ Test the Max! Cube. """
+    def test_set_mode_thermostat(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_1)
+        device = self.cube.devices[0]
+        self.assertEqual(21.0, device.target_temperature)
+        self.cube.set_mode(device, MAX_DEVICE_MODE_MANUAL)
 
-    def setUp(self):
-        self.cube = MaxCube(MaxCubeConnectionMock(INIT_RESPONSE_2))
+        self.assertEqual(MAX_DEVICE_MODE_MANUAL, device.mode)
+        self.commander.send_radio_msg.assert_called_once()
+        self.commander.send_radio_msg.assert_called_with('00044000000006BC53016A')
 
-    def test_init(self):
+    def test_init_2(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_2)
         self.assertEqual('015d2a', self.cube.rf_address)
         self.assertEqual('Cube', self.cube.name)
         self.assertEqual('01.13', self.cube.firmware_version)
         self.assertEqual(3, len(self.cube.devices))
 
-    def test_parse_response(self):
-        self.cube.parse_response(INIT_RESPONSE_2)
-        self.assertEqual('015d2a', self.cube.rf_address)
-        self.assertEqual('Cube', self.cube.name)
-        self.assertEqual('01.13', self.cube.firmware_version)
-        self.assertEqual(3, len(self.cube.devices))
-
-    def test_parse_c_message_thermostat(self):
         device = self.cube.devices[0]
         self.assertEqual(21.5, device.comfort_temperature)
         self.assertEqual(16.5, device.eco_temperature)
@@ -184,15 +252,28 @@ class TestMaxCubeExtended(unittest.TestCase):
         device = self.cube.devices[2]
         self.assertEqual(1, device.initialized)
 
-    def test_parse_h_message(self):
-        self.cube.parse_h_message('H:KEQ0566338,0b6444,0113,00000000,335b04d2,33,32,0f0c1d,101c,03,0000')
-        self.assertEqual('0b6444', self.cube.rf_address)
-        self.assertEqual('01.13', self.cube.firmware_version)
+        device = self.cube.devices[0]
+        self.assertEqual(MAX_DEVICE_MODE_AUTOMATIC, device.mode)
+        self.assertIsNone(device.actual_temperature)
+        self.assertEqual(8.0, device.target_temperature)
 
-    def test_parse_m_message(self):
-        self.cube.parse_m_message('M:00,01,VgIEAQdLaXRjaGVuBrxTAgZMaXZpbmcGvFoDCFNsZWVwaW5nCKuCBARXb3JrBrxcBAEGvF'
-                                  'NLRVEwMzM2MTA4B0tpdGNoZW4BAQa8WktFUTAzMzYxMDAGTGl2aW5nAgEIq4JLRVEwMzM1NjYyCFNs'
-                                  'ZWVwaW5nAwEGvFxLRVEwMzM2MTA0BFdvcmsEAQ==')
+        device = self.cube.devices[1]
+        self.assertEqual(MAX_DEVICE_MODE_AUTOMATIC, device.mode)
+        self.assertEqual(22.9, device.actual_temperature)
+        self.assertEqual(8.0, device.target_temperature)
+
+        device = self.cube.devices[2]
+        self.assertFalse(device.is_open)
+
+    def test_parse_m_message(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_2)
+        self.__update([Message.decode(
+            b'M:00,01,VgIEAQdLaXRjaGVuBrxTAgZMaXZpbmcGvFoDCFNsZWVwaW5nCKuCBARXb3JrBrxcBAEGvF' \
+            b'NLRVEwMzM2MTA4B0tpdGNoZW4BAQa8WktFUTAzMzYxMDAGTGl2aW5nAgEIq4JLRVEwMzM1NjYyCFNs' \
+            b'ZWVwaW5nAwEGvFxLRVEwMzM2MTA0BFdvcmsEAQ=='),
+            INIT_RESPONSE_2[-1]
+        ])
+
         self.assertEqual('0E2EBA', self.cube.devices[0].rf_address)
         self.assertEqual('Thermostat', self.cube.devices[0].name)
         self.assertEqual(MAX_THERMOSTAT, self.cube.devices[0].type)
@@ -209,7 +290,7 @@ class TestMaxCubeExtended(unittest.TestCase):
         self.assertEqual('Fensterkontakt', self.cube.devices[2].name)
         self.assertEqual(MAX_WINDOW_SHUTTER, self.cube.devices[2].type)
         self.assertEqual('KEQ0839778', self.cube.devices[2].serial)
-        self.assertEqual(1, self.cube.devices[3].room_id)
+        self.assertEqual(1, self.cube.devices[2].room_id)
 
         self.assertEqual('Kitchen', self.cube.rooms[0].name)
         self.assertEqual(1, self.cube.rooms[0].id)
@@ -217,90 +298,13 @@ class TestMaxCubeExtended(unittest.TestCase):
         self.assertEqual('Living', self.cube.rooms[1].name)
         self.assertEqual(2, self.cube.rooms[1].id)
 
-    def test_parse_l_message(self):
-        device = self.cube.devices[0]
-        self.assertEqual(MAX_DEVICE_MODE_AUTOMATIC, device.mode)
-        self.assertEqual(None, device.actual_temperature)
-        self.assertEqual(8.0, device.target_temperature)
-
-        device = self.cube.devices[1]
-        self.assertEqual(MAX_DEVICE_MODE_AUTOMATIC, device.mode)
-        self.assertEqual(22.9, device.actual_temperature)
-        self.assertEqual(8.0, device.target_temperature)
-
-        device = self.cube.devices[2]
-        self.assertEqual(False, device.is_open)
-
-    def test_resolve_device_mode(self):
-        self.assertEqual(MAX_DEVICE_MODE_AUTOMATIC, self.cube.resolve_device_mode(24))
-        self.assertEqual(MAX_DEVICE_MODE_MANUAL, self.cube.resolve_device_mode(25))
-
-    def test_is_thermostat(self):
-        device = MaxDevice()
-        device.type = MAX_CUBE
-        self.assertEqual(False, device.is_thermostat())
-        device.type = MAX_THERMOSTAT
-        self.assertEqual(True, device.is_thermostat())
-        device.type = MAX_THERMOSTAT_PLUS
-        self.assertEqual(True, device.is_thermostat())
-        device.type = MAX_WALL_THERMOSTAT
-        self.assertEqual(False, device.is_thermostat())
-        device.type = MAX_WINDOW_SHUTTER
-        self.assertEqual(False, device.is_thermostat())
-
-    def test_is_wall_thermostat(self):
-        device = MaxDevice()
-        device.type = MAX_CUBE
-        self.assertEqual(False, device.is_wallthermostat())
-        device.type = MAX_THERMOSTAT
-        self.assertEqual(False, device.is_wallthermostat())
-        device.type = MAX_THERMOSTAT_PLUS
-        self.assertEqual(False, device.is_wallthermostat())
-        device.type = MAX_WALL_THERMOSTAT
-        self.assertEqual(True, device.is_wallthermostat())
-        device.type = MAX_WINDOW_SHUTTER
-        self.assertEqual(False, device.is_wallthermostat())
-
-    def test_is_window_shutter(self):
-        device = MaxDevice()
-        device.type = MAX_CUBE
-        self.assertEqual(False, device.is_windowshutter())
-        device.type = MAX_THERMOSTAT
-        self.assertEqual(False, device.is_windowshutter())
-        device.type = MAX_THERMOSTAT_PLUS
-        self.assertEqual(False, device.is_windowshutter())
-        device.type = MAX_WALL_THERMOSTAT
-        self.assertEqual(False, device.is_windowshutter())
-        device.type = MAX_WINDOW_SHUTTER
-        self.assertEqual(True, device.is_windowshutter())
-
-    def test_set_target_temperature_thermostat(self):
-        self.cube.set_target_temperature(self.cube.devices[0], 24.5)
-        self.assertEqual('s:AARAAAAADi66ATE=\r\n', self.cube.connection.command)
-        self.assertEqual(24.5, self.cube.devices[0].target_temperature)
-
-    def test_set_target_temperature_windowshutter(self):
-        self.cube.set_target_temperature(self.cube.devices[2], 24.5)
-        self.assertEqual(None, self.cube.connection.command)
-
-    def test_set_mode_thermostat(self):
-        self.cube.set_mode(self.cube.devices[0], MAX_DEVICE_MODE_MANUAL)
-        self.assertEqual('s:AARAAAAADi66AVA=\r\n', self.cube.connection.command)
-        self.assertEqual(MAX_DEVICE_MODE_MANUAL, self.cube.devices[0].mode)
-
-    def test_set_mode_windowshutter(self):
-        self.cube.set_mode(self.cube.devices[2], 24.5)
-        self.assertEqual(None, self.cube.connection.command)
-
-    def test_set_temperature_mode_thermostat(self):
-        self.cube.set_temperature_mode(self.cube.devices[2], 24.5, MAX_DEVICE_MODE_BOOST)
-        self.assertEqual(None, self.cube.connection.command)
-
-    def test_get_devices(self):
+    def test_get_devices(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_2)
         devices = self.cube.get_devices()
         self.assertEqual(3, len(devices))
 
-    def test_device_by_rf(self):
+    def test_device_by_rf(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_2)
         device = self.cube.device_by_rf('0CA2B2')
 
         self.assertEqual('0CA2B2', device.rf_address)
@@ -309,24 +313,28 @@ class TestMaxCubeExtended(unittest.TestCase):
         self.assertEqual('KEQ0839778', device.serial)
         self.assertEqual(1, device.room_id)
 
-    def test_device_by_rf_negative(self):
+    def test_device_by_rf_negative(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_2)
         device = self.cube.device_by_rf('DEADBEEF')
 
-        self.assertEqual(None, device)
+        self.assertIsNone(device)
 
-    def test_devices_by_room(self):
+    def test_devices_by_room(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_2)
         room = MaxRoom()
         room.id = 1
         devices = self.cube.devices_by_room(room)
         self.assertEqual(2, len(devices))
 
-    def test_devices_by_room_negative(self):
+    def test_devices_by_room_negative(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_2)
         room = MaxRoom()
         room.id = 3
         devices = self.cube.devices_by_room(room)
         self.assertEqual(0, len(devices))
 
-    def test_get_rooms(self):
+    def test_get_rooms(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_2)
         rooms = self.cube.get_rooms()
 
         self.assertEqual('Badezimmer', rooms[0].name)
@@ -335,19 +343,23 @@ class TestMaxCubeExtended(unittest.TestCase):
         self.assertEqual('Wohnzimmer', rooms[1].name)
         self.assertEqual(2, rooms[1].id)
 
-    def test_room_by_id(self):
+    def test_room_by_id(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_2)
         room = self.cube.room_by_id(1)
 
         self.assertEqual('Badezimmer', room.name)
         self.assertEqual(1, room.id)
 
-    def test_room_by_id_negative(self):
+    def test_room_by_id_negative(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_2)
         room = self.cube.room_by_id(3)
 
-        self.assertEqual(None, room)
+        self.assertIsNone(room)
 
-    def test_set_programme(self):
-        self.cube.set_programme(
+    def test_set_programme(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_2)
+        self.commander.send_radio_msg.return_value=True
+        result = self.cube.set_programme(
             self.cube.devices[0],
             "saturday",
             [
@@ -355,17 +367,21 @@ class TestMaxCubeExtended(unittest.TestCase):
                 {'temp': 18, 'until': '24:00'}
             ]
         )
-        self.assertEqual('s:AAAQAAAADi66AQBSokkgAAAAAAA=\r\n', self.cube.connection.command)
+        self.assertTrue(result)
+        self.commander.send_radio_msg.assert_called_once()
+        self.commander.send_radio_msg.assert_called_with('0000100000000E2EBA010052A249200000000000')
 
-    def test_set_programme_already_existing_does_nothing(self):
+    def test_set_programme_already_existing_does_nothing(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_2)
         result = self.cube.set_programme(
             self.cube.devices[0],
             'saturday',
             INIT_PROGRAMME_1['saturday'])
-        self.assertEqual(result, None)
-        self.assertEqual(self.cube.connection.command, None)
+        self.assertIsNone(result)
+        self.commander.send_radio_msg.assert_not_called()
 
-    def test_get_device_as_dict(self):
+    def test_get_device_as_dict(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_2)
         device = self.cube.devices[0]
         result = device.to_dict()
         self.assertEqual(result['name'], 'Thermostat')

--- a/tests/test_deadline.py
+++ b/tests/test_deadline.py
@@ -1,0 +1,59 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, call, patch
+from maxcube.deadline import Deadline, Timeout
+
+ZERO_TIMEOUT = Timeout('zero', 0)
+ONE_TIMEOUT = Timeout('one', 1)
+ROOT_TIMEOUT = Timeout('root', 10)
+
+@patch('maxcube.deadline.time')
+class TestDeadline(TestCase):
+    """ Test Deadlines """
+
+    def testDeadlineLowerBoundForRemainingTime(self, timeMock):
+        timeMock.side_effect = [0, 0.4, 0.6]
+        deadline = ONE_TIMEOUT.deadline()
+        self.assertAlmostEqual(0.6, deadline.remaining(lower_bound=0.50))
+        self.assertAlmostEqual(0.5, deadline.remaining(lower_bound=0.50))
+
+    def testDeadlineUpperBoundForRemainingTime(self, timeMock):
+        timeMock.side_effect = [0, 0.4, 0.6]
+        deadline = ONE_TIMEOUT.deadline()
+        self.assertAlmostEqual(0.5, deadline.remaining(upper_bound=0.50))
+        self.assertAlmostEqual(0.4, deadline.remaining(upper_bound=0.50))
+
+    def testDeadlineIsExpired(self, timeMock):
+        timeMock.side_effect = [0, 0.4, 1.0, 1.000001]
+        deadline = ONE_TIMEOUT.deadline()
+        self.assertFalse(deadline.is_expired())
+        self.assertTrue(deadline.is_expired())
+        self.assertTrue(deadline.is_expired())
+
+    def testZeroDeadlineIsAlreadyExpired(self, timeMock):
+        timeMock.side_effect = [0.0, 0.0]
+        deadline = ZERO_TIMEOUT.deadline()
+        self.assertEquals('zero', deadline.fullname())
+        self.assertTrue(deadline.is_expired())
+
+    def testSubtimeoutHandling(self, timeMock):
+        timeMock.side_effect = [0.0, 0.1, 0.2]
+        deadline = ROOT_TIMEOUT.deadline()
+        subdeadline = deadline.subtimeout(ONE_TIMEOUT)
+        self.assertEquals('root:one', subdeadline.fullname())
+        self.assertAlmostEqual(0.9, subdeadline.remaining())
+
+    def testSubtimeoutHandlingWhenLargerThanTimeout(self, timeMock):
+        timeMock.side_effect = [0.0, 9.1, 9.2]
+        deadline = ROOT_TIMEOUT.deadline()
+        subdeadline = deadline.subtimeout(ONE_TIMEOUT)
+        self.assertAlmostEqual(0.8, subdeadline.remaining())
+
+    def testToString(self, timeMock):
+        timeMock.side_effect = [0.0, 0.1]
+        deadline = ONE_TIMEOUT.deadline()
+        self.assertEquals('Deadline one will expire in 0.900 seconds', str(deadline))
+
+    def testToStringForExpiredDeadline(self, timeMock):
+        timeMock.side_effect = [0.0, 1.1]
+        deadline = ONE_TIMEOUT.deadline()
+        self.assertEquals('Deadline one expired 0.100 seconds ago', str(deadline))

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,0 +1,15 @@
+from unittest import TestCase
+from maxcube.message import Message
+
+class TestMessage(TestCase):
+    """ Test Max! Cube messages """
+
+    def testDecodeValidMessage(self):
+        line = b's:AARAAAAABrxTAWo=\r\n'
+        msg = Message.decode(line)
+        self.assertEquals(Message('s', 'AARAAAAABrxTAWo='), msg)
+        self.assertEquals('S', msg.reply_cmd())
+        self.assertEquals(line, msg.encode())
+
+    def testDecodeEmptyMessage(self):
+        self.assertEquals(Message(''), Message.decode(b'\r\n'))


### PR DESCRIPTION
## Description
Refactor connection handling to use persistent connections and
reduce the chance of hitting a known bug in the Max! Cube that
resets to factory setting once every 50,000 connections.

## Issues fixed:
   - [MaxCube reset to fatory defaults](https://github.com/hackercowboy/python-maxcube-api/issues/12)
   - [Unable to change back to scheduled temperature (auto mode)](https://github.com/hackercowboy/python-maxcube-api/issues/24)
   
## Breaking changes:
     - MaxCubeConnection object removed. MaxCube constructor now receives
       the host and port parameters directly
     - The connection is not released after each command is send. This
       can block other applications to connect to the Max! Cube. You
       can call cube disconnect() method to release the connection
       manually.