### PR TITLE
Do not require connection port

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,9 +11,8 @@ Basic usage:
 .. code:: python
 
     from maxcube.cube import MaxCube
-    from maxcube.connection import MaxCubeConnection
 
-    cube = MaxCube(MaxCubeConnection('192.168.0.20', 62910))
+    cube = MaxCube('192.168.0.20')
 
     for device in cube.devices:
         print(device.name)

--- a/maxcube/cube.py
+++ b/maxcube/cube.py
@@ -27,12 +27,13 @@ UNKNOWN = "00"
 RF_FLAG_IS_ROOM = "04"
 RF_FLAG_IS_DEVICE = "00"
 RF_NULL_ADDRESS = "000000"
+DEFAULT_PORT = 62910
 DAYS = ['saturday', 'sunday', 'monday', 'tuesday', 'wednesday', 'thursday',
         'friday', 'saturday', 'sunday']
 
 
 class MaxCube(MaxDevice):
-    def __init__(self, host: str, port: int):
+    def __init__(self, host: str, port: int = DEFAULT_PORT):
         super(MaxCube, self).__init__()
         self.__commander = Commander(host, port)
         self.name = 'Cube'


### PR DESCRIPTION
MAX! Cubes always use TCP port 62910; we do not need to specify it.