### PR TITLE
Support non persistent connections

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,3 +11,10 @@
      can block other applications to connect to the Max! Cube. You
      can call cube disconnect() method to release the connection
      manually.
+
+### Version 0.4.1
+ * Several minor changes:
+   - Allow to rollback to non-persistent connections to keep using original software for unsupported operations
+   - Serial number of the cube was not extracted from handshake
+   - When changing to auto mode, use weekly programme to fetch current temperature
+   - Make MAX! Cube TCP port optional

--- a/maxcube/commander.py
+++ b/maxcube/commander.py
@@ -26,6 +26,7 @@ class Commander(object):
     def __init__(self, host: str, port: int):
         self.__host: str = host
         self.__port: int = port
+        self.use_persistent_connection = True
         self.__connection: Connection = None
         self.__unsolicited_messages: List[Message] = []
 
@@ -54,6 +55,8 @@ class Commander(object):
                 self.__connect(deadline)
         else:
             self.__connect(deadline)
+        if not self.use_persistent_connection:
+            self.disconnect()
         return self.get_unsolicited_messages()
 
     def send_radio_msg(self, hex_radio_msg: str) -> bool:
@@ -100,6 +103,10 @@ class Commander(object):
                 return self.__call(msg, deadline)
             else:
                 raise
+
+        finally:
+            if not self.use_persistent_connection:
+                self.disconnect()
 
     def __is_connected(self) -> bool:
         return self.__connection is not None

--- a/maxcube/cube.py
+++ b/maxcube/cube.py
@@ -44,6 +44,14 @@ class MaxCube(MaxDevice):
         self.update()
         self.log()
 
+    @property
+    def use_persistent_connection(self) -> bool:
+        return self.__commander.use_persistent_connection
+
+    @use_persistent_connection.setter
+    def use_persistent_connection(self, value: bool) -> None:
+        self.__commander.use_persistent_connection = value
+
     def disconnect(self):
         self.__commander.disconnect()
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.rst') as f:
 
 setup(
     name='maxcube-api',
-    version='0.4.0',
+    version='0.4.1',
     description='eQ-3/ELV MAX! Cube Python API',
     long_description=readme,
     author='David Uebelacker',

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -154,6 +154,13 @@ class TestMaxCube(TestCase):
         self.cube.disconnect()
         self.commander.disconnect.assert_called_once()
 
+    def test_use_persistent_connection(self, ClassMock):
+        self.init(ClassMock, INIT_RESPONSE_1)
+        self.commander.use_persistent_connection = True
+        self.assertTrue(self.cube.use_persistent_connection)
+        self.cube.use_persistent_connection = False
+        self.assertFalse(self.commander.use_persistent_connection)
+
     def test_is_thermostat(self, _):
         device = MaxDevice()
         device.type = MAX_CUBE


### PR DESCRIPTION
Support non-persistent connections like version 0.3.0 and previous ones. This allows us to keep using original MAX! software to perform operations still not supported by this library like paring new devices, removing devices, renaming rooms...