### PR TITLE
Fix push validation errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
       - id: check-executables-have-shebangs
         stages: [manual]
       - id: no-commit-to-branch
+        stages: [commit]
         args:
           - --branch=master
   - repo: https://github.com/adrienverge/yamllint.git


### PR DESCRIPTION
Do not check branch name on push, only on commit.