### PR TITLE
Fix parsing of command S response

### DIFF
--- a/maxcube/commander.py
+++ b/maxcube/commander.py
@@ -73,13 +73,13 @@ class Commander(object):
         try:
             response = self.__call(request, deadline)
             duty_cycle, status_code, free_slots = response.arg.split(",", 3)
-            if int(status_code) == 0:
+            if status_code == "0":
                 return True
             logger.debug(
                 "Radio message %s was not send [DutyCycle:%s, StatusCode:%s, FreeSlots:%s]"
                 % (request, duty_cycle, status_code, free_slots)
             )
-            if int(duty_cycle) == 100 and int(free_slots) == 0:
+            if int(duty_cycle, 16) == 100 and int(free_slots, 16) == 0:
                 sleep(deadline.remaining(upper_bound=10.0))
         except Exception as ex:
             logger.error("Error sending radio message to Max! Cube: " + str(ex))

--- a/tests/test_commander.py
+++ b/tests/test_commander.py
@@ -12,8 +12,8 @@ L_CMD_SUCCESS = Message("L")
 S_CMD_HEX = "FF00"
 S_CMD = Message("s", base64.b64encode(bytearray.fromhex(S_CMD_HEX)).decode("utf-8"))
 S_CMD_SUCCESS = Message("S", "00,0,31")
-S_CMD_ERROR = Message("S", "100,1,31")
-S_CMD_THROTTLE_ERROR = Message("S", "100,1,0")
+S_CMD_ERROR = Message("S", "64,1,1f")
+S_CMD_THROTTLE_ERROR = Message("S", "64,1,0")
 Q_CMD = Message("q")
 
 TEST_TIMEOUT = Timeout("test", 1.0)


### PR DESCRIPTION
Response to command S contains number in hexadecimal format. That
caused an exception when trying to parse values containing letters.