### PR TITLE
Add datetime provider to cube constructor

### DIFF
--- a/maxcube/cube.py
+++ b/maxcube/cube.py
@@ -1,7 +1,9 @@
 import base64
+from datetime import datetime
 import json
 import logging
 import struct
+from typing import Callable
 
 from maxcube.device import (
     MAX_CUBE,
@@ -42,7 +44,12 @@ DAYS = [
 
 
 class MaxCube(MaxDevice):
-    def __init__(self, host: str, port: int = DEFAULT_PORT):
+    def __init__(
+        self,
+        host: str,
+        port: int = DEFAULT_PORT,
+        now: Callable[[], datetime] = datetime.now,
+    ):
         super(MaxCube, self).__init__()
         self.__commander = Commander(host, port)
         self.name = "Cube"
@@ -50,6 +57,7 @@ class MaxCube(MaxDevice):
         self.firmware_version = None
         self.devices = []
         self.rooms = []
+        self._now: Callable[[], datetime] = now
         self.update()
         self.log()
 
@@ -301,8 +309,8 @@ class MaxCube(MaxDevice):
             if temperature > 0:
                 thermostat.target_temperature = int(temperature * 2) / 2.0
             elif mode == MAX_DEVICE_MODE_AUTOMATIC:
-                thermostat.target_temperature = (
-                    thermostat.get_current_temp_in_auto_mode()
+                thermostat.target_temperature = thermostat.get_programmed_temp_at(
+                    self._now()
                 )
             return True
         return False

--- a/maxcube/thermostat.py
+++ b/maxcube/thermostat.py
@@ -1,4 +1,4 @@
-from time import localtime
+from datetime import datetime
 from typing import Dict, List
 
 from maxcube.device import MODE_NAMES, MaxDevice
@@ -39,11 +39,15 @@ class MaxThermostat(MaxDevice):
             f"valve={self.valve_position}",
         )
 
-    def get_current_temp_in_auto_mode(self):
-        t = localtime()
-        weekday = PROG_DAYS[t.tm_wday]
-        time = f"{t.tm_hour:02}:{t.tm_min:02}"
+    def get_programmed_temp_at(self, dt: datetime):
+        """Retrieve the programmed temperature at the given instant."""
+        weekday = PROG_DAYS[dt.weekday()]
+        time = f"{dt.hour:02}:{dt.minute:02}"
         for point in self.programme.get(weekday, []):
             if time < point["until"]:
                 return point["temp"]
         return None
+
+    def get_current_temp_in_auto_mode(self):
+        """DEPRECATED: use get_programmed_temp_at instead."""
+        return self.get_programmed_temp_at(datetime.now())

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -1,4 +1,4 @@
-from time import strptime
+from datetime import datetime
 from typing import List
 from unittest import TestCase
 from unittest.mock import patch
@@ -104,7 +104,7 @@ class TestMaxCube(TestCase):
         self.commander = ClassMock.return_value
         self.commander.update.return_value = responses
 
-        self.cube = MaxCube("host", 1234)
+        self.cube = MaxCube("host", 1234, now=lambda: datetime(2012, 10, 22, 5, 30))
 
         self.commander.update.assert_called_once()
         self.commander.update.reset_mock()
@@ -424,10 +424,7 @@ class TestMaxCube(TestCase):
             ],
         )
 
-    @patch("maxcube.thermostat.localtime")
-    def test_set_auto_mode_read_temp_from_program(self, localtime_mock, ClassMock):
-        localtime_mock.return_value = strptime("2012-10-22T05:30", "%Y-%m-%dT%H:%M")
-        print(localtime_mock.return_value)
+    def test_set_auto_mode_read_temp_from_program(self, ClassMock):
         self.init(ClassMock, INIT_RESPONSE_2)
         device = self.cube.devices[0]
         self.assertEqual(8.0, device.target_temperature)


### PR DESCRIPTION
Allow to pass a datetime provider to the constructor of MaxCube to
support HASS, where operating system timezone is always UTC and
the correct timezone is configured in HA core.